### PR TITLE
Modified the harvestLinks method in Krawler to filter out URLs that s…

### DIFF
--- a/src/main/kotlin/io/thelandscape/krawler/crawler/Krawler.kt
+++ b/src/main/kotlin/io/thelandscape/krawler/crawler/Krawler.kt
@@ -398,6 +398,8 @@ abstract class Krawler(val config: KrawlConfig = KrawlConfig(),
                 // Anchor tags
                 doc.anchorTags
                         .filterNot { it.attr("href").startsWith("#") }
+                        .filterNot { it.attr("href").startsWith("tel") }
+                        .filterNot { it.attr("href").startsWith("javascript") }
                         .filter { it.attr("href").length <= 2048 }
                         .map { KrawlUrl.new(it.attr("href"), url) }
                         .filter { it.canonicalForm.isNotBlank() }


### PR DESCRIPTION
Modified the harvestLinks method in Krawler to filter out URLs that start with "tel" or "javascript" . This is in response to a bug that caused the Krawler to stop when it found a link like these. Brian and I think an error with the URL was causing the thread to stop; ... then "job.isActive()" evaluates to true, and the crawl finishes when it shouldn't.