### PR TITLE
 Remove unsafe dereference operations

### DIFF
--- a/src/main/kotlin/io/thelandscape/krawler/robots/RoboMinder.kt
+++ b/src/main/kotlin/io/thelandscape/krawler/robots/RoboMinder.kt
@@ -90,6 +90,7 @@ class RoboMinder(private val userAgent: String,
             rules.put(url.hierarchicalPart, process(resp))
         }
 
-        return rules.getIfPresent(url.hierarchicalPart)!!.invoke(withoutGetParams)
+        val rule = rules.getIfPresent(url.hierarchicalPart) ?: return true
+        return rule(withoutGetParams)
     }
 }

--- a/src/main/kotlin/io/thelandscape/krawler/robots/RobotsTxt.kt
+++ b/src/main/kotlin/io/thelandscape/krawler/robots/RobotsTxt.kt
@@ -28,8 +28,7 @@ class RobotsTxt(url: KrawlUrl, response: HttpResponse, context: HttpClientContex
 
     // TODO: Improve handling: https://en.wikipedia.org/wiki/Robots_exclusion_standard#About_the_standard
 
-    var disallowRules: Map<String, MutableSet<String>> = mapOf()
-        private set
+    val disallowRules: Map<String, MutableSet<String>>
 
     // Do all the parsing in a single pass in here
     init {
@@ -47,14 +46,12 @@ class RobotsTxt(url: KrawlUrl, response: HttpResponse, context: HttpClientContex
             if (key == "user-agent") {
                 userAgent = value
                 continue
-            }
-
-            if (key == "disallow") {
-                if (userAgent in rules)
-                    rules[userAgent]!!.add(value)
-                else
+            } else if (key == "disallow") {
+                if (userAgent in rules) {
+                    rules.getOrPut(userAgent, { mutableSetOf() }).add(value)
+                } else {
                     rules[userAgent] = mutableSetOf(value)
-
+                }
                 continue
             }
         }

--- a/src/test/kotlin/io/thelandscape/KrawlQueueDaoTest.kt
+++ b/src/test/kotlin/io/thelandscape/KrawlQueueDaoTest.kt
@@ -61,7 +61,7 @@ class KrawlQueueDaoTest {
                 KrawlQueueEntry("http://www.e5.com/", 0, KrawlHistoryEntry(), timestamp = LocalDateTime.now())
         )
         queueDao.push(pushers)
-        val res = queueDao.deleteByAge(LocalDateTime.now())
-        assertEquals(5, res)
+        val res = queueDao.deleteByAge(LocalDateTime.now().minusDays(1))
+        assertEquals(2, res)
     }
 }

--- a/src/test/kotlin/io/thelandscape/KrawlQueueDaoTest.kt
+++ b/src/test/kotlin/io/thelandscape/KrawlQueueDaoTest.kt
@@ -61,7 +61,7 @@ class KrawlQueueDaoTest {
                 KrawlQueueEntry("http://www.e5.com/", 0, KrawlHistoryEntry(), timestamp = LocalDateTime.now())
         )
         queueDao.push(pushers)
-        val res = queueDao.deleteByAge(LocalDateTime.now().minusDays(1))
-        assertEquals(2, res)
+        val res = queueDao.deleteByAge(LocalDateTime.now())
+        assertEquals(5, res)
     }
 }


### PR DESCRIPTION
I've got of every unsafe dereference `!!`. I hope the default case in RoboMinder is ok.